### PR TITLE
fix api parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ You can also specify board access policy, including individual users by email an
 ```js
 {
     "name": "board name as string",
-    "accessPolicy": [
-        { email: "coolgirl@reaktor.com" },
-        { domain: "reaktor.fi" }
-    ]
+    "accessPolicy": {
+        "allowList": [
+            { email: "coolgirl@reaktor.com" },
+            { domain: "reaktor.fi" }
+        ]
+    }
 }
 ```
 


### PR DESCRIPTION
The parameter described in README is wrong. Based on the current code,  `allowList` is required for accessPolicy.

https://github.com/raimohanska/ourboard/blob/ead6803fe9aa130b9da3aa16c38d8364028d79d1/backend/src/api/api-routes.openapi.ts#L19