### PR TITLE
Create some issue templates for logging bugs or issues or feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a bug report to help us out
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Feature request story or issue
+
+## Screenshot
+
+YOUR SCREENSHOT HERE: 
+
+## Url
+
+- Url where you took the screenshot:
+ - URL: 
+
+## A sentence description of the problem
+
+Short DESCRIPTION: 
+
+
+
+That's it!  Thanks.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? There is a  Please describe.**
+A clear and concise description of what the problem is. Ex. When I want to do X, I am always missing Y to make it easier [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Take a screenshot of the area you're working in**
+Even if the feature request doesn't exist there yet, what area would the feature request help within?
+SCREENSHOT:
+
+URL (of where you're working):
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Looks like you don't currently have a template for when people open issues.  To get more useful issues opened, it always helps to provide some structured guidance in the issue templates.

Creates two markdown files in a new .github/ISSUE_TEMPLATE/ directory.