### PR TITLE
Refine API access controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ For a full list of API endpoints, see https://ourboard.io/api-docs.
 
 All POST and PUT endpoints accept application/json content.
 
-API requests against boards with restricted access require you to supply an API_TOKEN header with a valid API token.
-The token is returned in the response of the POST request used to create the board.
+API requests against boards with restricted access require you to supply a board-specific API_TOKEN
+as a HTTP header. The token is returned in the response of the POST request used to create the board.
+As a result, only boards created using the API can have an API_TOKEN at the moment.
 
 ### POST /api/v1/board
 

--- a/backend/src/api/board-csv-get.ts
+++ b/backend/src/api/board-csv-get.ts
@@ -18,7 +18,7 @@ export const boardCSVGet = route
     .get("/api/v1/board/:boardId/csv")
     .use(apiTokenHeader)
     .handler((request) =>
-        checkBoardAPIAccess(request, async (boardState) => {
+        checkBoardAPIAccess("read", request, async (boardState) => {
             const board = boardState.board
             const textItemsWithParent = Object.values(board.items).filter(
                 (i) => i.containerId !== undefined && (i.type === "text" || i.type === "note"),

--- a/backend/src/api/board-get.ts
+++ b/backend/src/api/board-get.ts
@@ -10,7 +10,7 @@ export const boardGet = route
     .get("/api/v1/board/:boardId")
     .use(apiTokenHeader)
     .handler((request) =>
-        checkBoardAPIAccess(request, async (boardState) => {
+        checkBoardAPIAccess("read", request, async (boardState) => {
             return ok({ board: boardState.board })
         }),
     )

--- a/backend/src/api/board-hierarchy-get.ts
+++ b/backend/src/api/board-hierarchy-get.ts
@@ -11,7 +11,7 @@ export const boardHierarchyGet = route
     .get("/api/v1/board/:boardId/hierarchy")
     .use(apiTokenHeader)
     .handler((request) =>
-        checkBoardAPIAccess(request, async (boardState) => {
+        checkBoardAPIAccess("read", request, async (boardState) => {
             const board = boardState.board
             return ok({ board: getBoardHierarchy(boardState.board) })
         }),

--- a/backend/src/api/board-history-get.ts
+++ b/backend/src/api/board-history-get.ts
@@ -12,7 +12,7 @@ export const boardHistoryGet = route
     .get("/api/v1/board/:boardId/history")
     .use(apiTokenHeader)
     .handler((request) =>
-        checkBoardAPIAccess(request, async (board) => {
+        checkBoardAPIAccess("read", request, async (board) => {
             return ok(
                 streamingJSONBody("history", async (callback) => {
                     await withDBClient(

--- a/backend/src/api/board-update.ts
+++ b/backend/src/api/board-update.ts
@@ -15,7 +15,7 @@ export const boardUpdate = route
     .put("/api/v1/board/:boardId")
     .use(apiTokenHeader, body(t.type({ name: NonEmptyString, accessPolicy: BoardAccessPolicyCodec })))
     .handler((request) =>
-        checkBoardAPIAccess(request, async () => {
+        checkBoardAPIAccess("write", request, async () => {
             const { boardId } = request.routeParams
             const { name, accessPolicy } = request.body
             await updateBoard({ boardId, name, accessPolicy })

--- a/backend/src/api/item-create-or-update.ts
+++ b/backend/src/api/item-create-or-update.ts
@@ -43,7 +43,7 @@ export const itemCreateOrUpdate = route
         ),
     )
     .handler((request) =>
-        checkBoardAPIAccess(request, async (board) => {
+        checkBoardAPIAccess("write", request, async (board) => {
             const { itemId } = request.routeParams
             let {
                 type,

--- a/backend/src/api/item-create.ts
+++ b/backend/src/api/item-create.ts
@@ -17,7 +17,7 @@ export const itemCreate = route
         body(t.type({ type: t.literal("note"), text: t.string, color: t.string, container: t.string })),
     )
     .handler((request) =>
-        checkBoardAPIAccess(request, async (board) => {
+        checkBoardAPIAccess("write", request, async (board) => {
             const { type, text, color, container } = request.body
             console.log(`POST item for board ${board.board.id}: ${JSON.stringify(request.req.body)}`)
             addItem(board, type, text, color, container)

--- a/backend/src/api/utils.ts
+++ b/backend/src/api/utils.ts
@@ -9,6 +9,9 @@ import {
     AppEvent,
     Board,
     BoardHistoryEntry,
+    canRead,
+    canWrite,
+    checkBoardAccess,
     Color,
     Container,
     EventUserInfo,
@@ -23,6 +26,7 @@ export const route = applyMiddleware(wrapNative(bodyParser.json()))
 export const apiTokenHeader = headers(t.partial({ API_TOKEN: t.string }))
 
 export async function checkBoardAPIAccess<T>(
+    accessType: "read" | "write",
     request: { routeParams: { boardId: string }; headers: { API_TOKEN?: string | undefined } },
     fn: (board: ServerSideBoardState) => Promise<T>,
 ) {
@@ -31,9 +35,14 @@ export async function checkBoardAPIAccess<T>(
     try {
         const board = await getBoard(boardId)
         if (!board) return notFound()
-        if (board.board.accessPolicy || board.accessTokens.length) {
+        const accessLevel = checkBoardAccess(board.board.accessPolicy, {
+            nickname: "anonymous",
+            userType: "unidentified",
+        })
+        const publicAccessOk = accessType === "read" ? canRead(accessLevel) : canWrite(accessLevel)
+        if (!publicAccessOk) {
             if (!apiToken) {
-                return badRequest("API_TOKEN header is missing")
+                return badRequest("API_TOKEN header required for this board")
             }
             if (!board.accessTokens.some((t) => t === apiToken)) {
                 console.log(`API_TOKEN ${apiToken} not on list ${board.accessTokens}`)


### PR DESCRIPTION
- Now that an accesspolicy can allow public read/write, we cannot deny
  API access based on the existence of a policy
- Check for public read/write access in case of no API_KEY header
- A valid API_KEY header matching the boards API key grants unrestricted
  access