### PR TITLE
Treat connections as first-class citizens

### DIFF
--- a/common/src/action-folding.ts
+++ b/common/src/action-folding.ts
@@ -80,7 +80,7 @@ export function foldActions_(a: AppEvent, b: AppEvent, options: FoldOptions = de
     } else if (a.action === "item.front") {
         if (b.action === "item.front" && b.boardId === a.boardId && everyItemIdMatches(b, a)) return b
     } else if (a.action === "item.move") {
-        if (b.action === "item.move" && b.boardId === a.boardId && everyItemMatches(b, a)) return b
+        if (b.action === "item.move" && b.boardId === a.boardId && everyMovedItemMatches(b, a)) return b
     } else if (a.action === "item.update") {
         if (b.action === "item.update" && b.boardId === a.boardId && everyItemMatches(b, a)) return b
     } else if (a.action === "item.lock" || a.action === "item.unlock") {
@@ -91,14 +91,16 @@ export function foldActions_(a: AppEvent, b: AppEvent, options: FoldOptions = de
     return null
 }
 
-function everyItemMatches(evt: MoveItem | UpdateItem, evt2: MoveItem | UpdateItem) {
-    if (evt.action === "item.move" && evt.connections?.length) return false
-    if (evt2.action === "item.move" && evt2.connections?.length) return false
-    return (
-        evt.items.length === evt2.items.length &&
-        (evt.items as Item[]) /* TODO no assertion */
-            .every((it, ind) => evt2.items[ind].id === it.id)
-    )
+function everyItemMatches(evt: UpdateItem, evt2: UpdateItem) {
+    return arrayIdMatch(evt.items, evt2.items)
+}
+
+function everyMovedItemMatches(evt: MoveItem, evt2: MoveItem) {
+    return arrayIdMatch(evt.items, evt2.items) && arrayIdMatch(evt.connections || [], evt2.connections || [])
+}
+
+function arrayIdMatch<T extends { id: string }>(a: T[], b: T[]) {
+    return a.length === b.length && a.every((it, ind) => b[ind].id === it.id)
 }
 
 function everyItemIdMatches(evt: BringItemToFront, evt2: BringItemToFront) {

--- a/common/src/action-folding.ts
+++ b/common/src/action-folding.ts
@@ -92,6 +92,8 @@ export function foldActions_(a: AppEvent, b: AppEvent, options: FoldOptions = de
 }
 
 function everyItemMatches(evt: MoveItem | UpdateItem, evt2: MoveItem | UpdateItem) {
+    if (evt.action === "item.move" && evt.connections?.length) return false
+    if (evt2.action === "item.move" && evt2.connections?.length) return false
     return (
         evt.items.length === evt2.items.length &&
         (evt.items as Item[]) /* TODO no assertion */

--- a/common/src/board-reducer.ts
+++ b/common/src/board-reducer.ts
@@ -24,7 +24,7 @@ import {
 import _, { isArray } from "lodash"
 import { arrayToObject } from "./migration"
 import { maybeChangeContainer } from "../../frontend/src/board/item-setcontainer"
-import { rerouteConnection } from "./connection-utils"
+import { rerouteConnection, resolveEndpoint } from "./connection-utils"
 
 export function boardReducer(
     board: Board,
@@ -166,7 +166,9 @@ export function boardReducer(
                     }),
                     connections:
                         event.connections?.map((c) => {
-                            return { id: c.id, xDiff: -c.xDiff, yDiff: -c.yDiff }
+                            const conn = getConnection(board)(c.id)
+                            const startPoint = resolveEndpoint(conn.from, board)
+                            return { id: c.id, x: startPoint.x, y: startPoint.y }
                         }) || [],
                 },
             ]
@@ -334,10 +336,11 @@ function moveItems(board: Board, event: MoveItem) {
         } else {
             const m = connectionMovesInEvent.find((m) => m.id === connection.id)
             if (m) {
+                const startPoint = resolveEndpoint(connection.from, board)
                 connectionMoves[connection.id] = {
                     ends: "both",
-                    xDiff: m.xDiff,
-                    yDiff: m.yDiff,
+                    xDiff: m.x - startPoint.x,
+                    yDiff: m.y - startPoint.y,
                 }
             }
         }

--- a/common/src/connection-utils.ts
+++ b/common/src/connection-utils.ts
@@ -14,7 +14,7 @@ import {
     ItemAttachmentLocation,
     Point,
 } from "./domain"
-import { centerPoint, subtract } from "./geometry"
+import { centerPoint, Rect, subtract } from "./geometry"
 import { getAngleDeg, Vector2 } from "./vector2"
 
 export function resolveEndpoint(e: Point | Item | ConnectionEndPoint, b: Board | Record<string, Item>): Point | Item {
@@ -162,4 +162,22 @@ export function rerouteByNewControlPoints(c: Connection, controlPoints: Point[],
 
 function mid(x: number, y: number) {
     return (x + y) * 0.5
+}
+
+export const connectionRect = (b: Board | Record<string, Item>) => (c: Connection): Rect => {
+    const start = resolveEndpoint(c.from, b)
+    const end = resolveEndpoint(c.to, b)
+    const allPoints = [start, ...c.controlPoints, end]
+    const minX = _.min(allPoints.map((p) => p.x))!
+    const maxX = _.max(allPoints.map((p) => p.x))!
+    const minY = _.min(allPoints.map((p) => p.y))!
+    const maxY = _.max(allPoints.map((p) => p.y))!
+    const x = minX
+    if (isNaN(x)) {
+        throw Error("Assertion fail")
+    }
+    const y = minY
+    const width = maxX - minX
+    const height = maxY - minY
+    return { x, y, width, height }
 }

--- a/common/src/domain.ts
+++ b/common/src/domain.ts
@@ -263,6 +263,7 @@ export type MoveItem = {
     action: "item.move"
     boardId: Id
     items: { id: Id; x: number; y: number; containerId?: Id | undefined }[]
+    connections: { id: Id; xDiff: number; yDiff: number }[] | null // TODO: null is for legacy support
 }
 export type IncreaseItemFont = { action: "item.font.increase"; boardId: Id; itemIds: Id[] }
 export type DecreaseItemFont = { action: "item.font.decrease"; boardId: Id; itemIds: Id[] }
@@ -500,6 +501,12 @@ export const getItem = (boardOrItems: Board | Record<string, Item>) => (id: Id) 
     const item = findItem(boardOrItems)(id)
     if (!item) throw Error("Item not found: " + id)
     return item
+}
+
+export const getConnection = (b: Board) => (id: Id) => {
+    const conn = b.connections.find((c) => c.id === id)
+    if (!conn) throw Error("Connection not found: " + id)
+    return conn
 }
 
 export const findItem = (boardOrItems: Board | Record<string, Item>) => (id: Id) => {

--- a/common/src/domain.ts
+++ b/common/src/domain.ts
@@ -138,7 +138,7 @@ export type Video = ItemProperties & { type: typeof ITEM_TYPES.VIDEO; assetId: s
 export type Container = TextItemProperties & { type: typeof ITEM_TYPES.CONTAINER; color: Color }
 
 export type Point = { x: number; y: number }
-function Point(x: number, y: number) {
+export function Point(x: number, y: number) {
     return { x, y }
 }
 export const isPoint = (u: unknown): u is Point => typeof u === "object" && !!u && "x" in u && "y" in u
@@ -267,7 +267,7 @@ export type MoveItem = {
 export type IncreaseItemFont = { action: "item.font.increase"; boardId: Id; itemIds: Id[] }
 export type DecreaseItemFont = { action: "item.font.decrease"; boardId: Id; itemIds: Id[] }
 export type BringItemToFront = { action: "item.front"; boardId: Id; itemIds: Id[] }
-export type DeleteItem = { action: "item.delete"; boardId: Id; itemIds: Id[] }
+export type DeleteItem = { action: "item.delete"; boardId: Id; itemIds: Id[]; connectionIds: Id[] | null } // TODO: null is legacy support
 export type BootstrapBoard = { action: "item.bootstrap"; boardId: Id } & BoardContents
 export type LockItem = { action: "item.lock"; boardId: Id; itemId: Id }
 export type UnlockItem = { action: "item.unlock"; boardId: Id; itemId: Id }

--- a/common/src/domain.ts
+++ b/common/src/domain.ts
@@ -263,7 +263,7 @@ export type MoveItem = {
     action: "item.move"
     boardId: Id
     items: { id: Id; x: number; y: number; containerId?: Id | undefined }[]
-    connections: { id: Id; xDiff: number; yDiff: number }[] | null // TODO: null is for legacy support
+    connections: { id: Id; x: number; y: number }[] | null // Coords for start point. TODO: null is for legacy support
 }
 export type IncreaseItemFont = { action: "item.font.increase"; boardId: Id; itemIds: Id[] }
 export type DecreaseItemFont = { action: "item.font.decrease"; boardId: Id; itemIds: Id[] }

--- a/common/src/sets.ts
+++ b/common/src/sets.ts
@@ -12,3 +12,5 @@ export function difference<A>(setA: Set<A>, setB: Set<A>) {
     }
     return _difference
 }
+
+export const emptySet = <A>() => new Set<A>()

--- a/frontend/src/board/BoardView.tsx
+++ b/frontend/src/board/BoardView.tsx
@@ -12,7 +12,7 @@ import { CursorsStore } from "../store/cursors-store"
 import { UserSessionState } from "../store/user-session-store"
 import { boardCoordinateHelper } from "./board-coordinates"
 import { boardDragHandler } from "./board-drag"
-import { BoardFocus, getSelectedItemIds, getSelectedItem, getSelectedItems } from "./board-focus"
+import { BoardFocus, getSelectedItemIds, getSelectedItem, getSelectedItems, noFocus } from "./board-focus"
 import { boardScrollAndZoomHandler } from "./board-scroll-and-zoom"
 import { BoardToolLayer } from "./BoardToolLayer"
 import { ConnectionsView } from "./ConnectionsView"
@@ -121,7 +121,7 @@ export const BoardView = ({
         (e) => e.key === "Escape",
         () => {
             toolController.useDefaultTool()
-            focus.set({ status: "none" })
+            focus.set(noFocus)
         },
     )
     installKeyboardShortcut(plainKey("c"), () => toolController.tool.set("connect"))
@@ -130,12 +130,12 @@ export const BoardView = ({
         .forEach((event) => {
             if (!boardElement.get()!.contains(event.target as Node)) {
                 // Click outside => reset selection
-                focus.set({ status: "none" })
+                focus.set(noFocus)
             }
         })
 
     onClickOutside(boardElement, () => {
-        focus.set({ status: "none" })
+        focus.set(noFocus)
     })
 
     const { viewRect } = boardScrollAndZoomHandler(
@@ -165,7 +165,7 @@ export const BoardView = ({
                         coordinateHelper.currentBoardCoordinates.get(),
                     )
                 } else {
-                    focus.set({ status: "none" })
+                    focus.set(noFocus)
                 }
             }
         }

--- a/frontend/src/board/BoardView.tsx
+++ b/frontend/src/board/BoardView.tsx
@@ -38,6 +38,7 @@ import { ToolController } from "./tool-selection"
 import { BoardViewHeader } from "./toolbars/BoardViewHeader"
 import { VideoView } from "./VideoView"
 import { startConnecting } from "./item-connect"
+import { emptySet } from "../../../common/src/sets"
 
 const emptyNote = newNote("")
 
@@ -179,9 +180,9 @@ export const BoardView = ({
         dispatch({ action: "item.add", boardId, items: [item], connections: [] })
 
         if (item.type === "note" || item.type === "text") {
-            focus.set({ status: "editing", id: item.id })
+            focus.set({ status: "editing", itemId: item.id })
         } else {
-            focus.set({ status: "selected", ids: new Set([item.id]) })
+            focus.set({ status: "selected", itemIds: new Set([item.id]), connectionIds: emptySet() })
         }
     }
 

--- a/frontend/src/board/ConnectionsView.tsx
+++ b/frontend/src/board/ConnectionsView.tsx
@@ -63,7 +63,7 @@ export const ConnectionsView = ({
                     ...c,
                     from: determineAttachmenLocation(c.from, firstControlPoint, is),
                     to: determineAttachmenLocation(c.to, lastControlPoint, is),
-                    selected: f.status === "connection-selected" && f.ids.has(c.id),
+                    selected: f.status === "selected" && f.connectionIds.has(c.id),
                 }
             })
         },
@@ -180,10 +180,10 @@ export const ConnectionsView = ({
         const selectThisConnection = (e: JSX.MouseEvent) => {
             const id = cNode.get().id
             const f = focus.get()
-            if (e.shiftKey && f.status === "connection-selected") {
-                focus.set({ status: "connection-selected", ids: toggleInSet(id, f.ids) })
+            if (e.shiftKey && f.status === "selected") {
+                focus.set({ ...f, connectionIds: toggleInSet(id, f.connectionIds) })
             } else {
-                focus.set({ status: "connection-selected", ids: new Set([id]) })
+                focus.set({ status: "selected", connectionIds: new Set([id]), itemIds: emptySet() })
             }
         }
 
@@ -220,7 +220,7 @@ export const ConnectionsView = ({
 import { Bezier } from "bezier-js"
 import { BoardZoom } from "./board-scroll-and-zoom"
 import { findNearestAttachmentLocationForConnectionNode, resolveEndpoint } from "../../../common/src/connection-utils"
-import { toggleInSet } from "../../../common/src/sets"
+import { emptySet, toggleInSet } from "../../../common/src/sets"
 
 function quadraticCurveSVGPath(from: Point, to: Point, controlPoints: Point[]) {
     if (!controlPoints || !controlPoints.length) {

--- a/frontend/src/board/ConnectionsView.tsx
+++ b/frontend/src/board/ConnectionsView.tsx
@@ -15,7 +15,7 @@ import {
 import { findAttachmentLocation, resolveItemEndpoint } from "../../../common/src/connection-utils"
 import { Dispatch } from "../store/board-store"
 import { BoardCoordinateHelper } from "./board-coordinates"
-import { BoardFocus } from "./board-focus"
+import { BoardFocus, getSelectedConnectionIds } from "./board-focus"
 import * as G from "../../../common/src/geometry"
 import { existingConnectionHandler } from "./item-connect"
 import { Z_CONNECTIONS } from "./zIndices"
@@ -63,7 +63,7 @@ export const ConnectionsView = ({
                     ...c,
                     from: determineAttachmenLocation(c.from, firstControlPoint, is),
                     to: determineAttachmenLocation(c.to, lastControlPoint, is),
-                    selected: f.status === "selected" && f.connectionIds.has(c.id),
+                    selected: getSelectedConnectionIds(f).has(c.id),
                 }
             })
         },

--- a/frontend/src/board/HistoryView.tsx
+++ b/frontend/src/board/HistoryView.tsx
@@ -19,7 +19,7 @@ import {
 import { Checkbox } from "../components/components"
 import { HistoryIcon } from "../components/Icons"
 import { Dispatch } from "../store/board-store"
-import { BoardFocus, getSelectedItemIds } from "./board-focus"
+import { BoardFocus, getSelectedItemIds, noFocus } from "./board-focus"
 
 type ParsedHistoryEntry = {
     timestamp: ISOTimeStamp
@@ -59,7 +59,7 @@ export const HistoryView = ({
         // At least it's done only when the history table is visible and debounced with 1000 milliseconds.
         const parsedHistory = history.pipe(L.debounce(1000, componentScope()), L.map(parseFullHistory))
         const forSelectedItem = L.atom(false)
-        const historyFocus = L.view(focus, forSelectedItem, (f, s) => (s ? f : ({ status: "none" } as BoardFocus)))
+        const historyFocus = L.view(focus, forSelectedItem, (f, s) => (s ? f : noFocus))
         const focusedHistory = L.combine(parsedHistory, historyFocus, focusHistory)
         const clippedHistory = L.view(focusedHistory, clipHistory)
 

--- a/frontend/src/board/ItemView.tsx
+++ b/frontend/src/board/ItemView.tsx
@@ -13,6 +13,7 @@ import {
     ItemType,
     TextItem,
 } from "../../../common/src/domain"
+import { emptySet } from "../../../common/src/sets"
 import { HTMLEditableSpan } from "../components/HTMLEditableSpan"
 import { Dispatch } from "../store/board-store"
 import { autoFontSize } from "./autoFontSize"
@@ -141,7 +142,11 @@ export const ItemView = ({
 
         const setEditing = (e: boolean) => {
             dispatch({ action: "item.front", boardId: board.get().id, itemIds: [id] })
-            focus.set(e ? { status: "editing", id } : { status: "selected", ids: new Set([id]) })
+            focus.set(
+                e
+                    ? { status: "editing", itemId: id }
+                    : { status: "selected", itemIds: new Set([id]), connectionIds: emptySet() },
+            )
         }
         const color = L.view(item, getItemBackground, contrastingColor)
         const fontSize = autoFontSize(

--- a/frontend/src/board/SelectionBorder.tsx
+++ b/frontend/src/board/SelectionBorder.tsx
@@ -46,7 +46,7 @@ export const SelectionBorder = ({
 
     function DragCorner({ vertical, horizontal }: { vertical: Vertical; horizontal: Horizontal }) {
         const ref = (e: HTMLElement) =>
-            onBoardItemDrag(e, id, board, focus, coordinateHelper, false, (b, items, xDiff, yDiff) => {
+            onBoardItemDrag(e, id, board, focus, coordinateHelper, false, (b, items, connections, xDiff, yDiff) => {
                 const updatedItems = items.map(({ current, dragStartPosition }) => {
                     const maintainAspectRatio =
                         current.type === "image" || (current.type === "note" && current.shape !== "rect")

--- a/frontend/src/board/board-drag.ts
+++ b/frontend/src/board/board-drag.ts
@@ -99,8 +99,6 @@ export function boardDragHandler({
                             ...getSelectedConnectionIds(da.selectedAtStart),
                         ])
 
-                        console.log(connectionIds)
-
                         itemIds.size + connectionIds.size > 0
                             ? focus.set({ status: "selected", itemIds, connectionIds })
                             : focus.set(noFocus)

--- a/frontend/src/board/board-drag.ts
+++ b/frontend/src/board/board-drag.ts
@@ -9,6 +9,7 @@ import { componentScope } from "harmaja"
 import { Tool, ToolController } from "./tool-selection"
 import { Dispatch } from "../store/server-connection"
 import { drawConnectionHandler } from "./item-connect"
+import { emptySet } from "../../../common/src/sets"
 
 export type DragAction =
     | { action: "select"; selectedAtStart: Set<string> }
@@ -58,7 +59,11 @@ export function boardDragHandler({
                 dragAction.set({ action: "pan" })
             } else {
                 let selectedAtStart = e.shiftKey ? getSelectedItemIds(focus.get()) : new Set<string>()
-                focus.set(selectedAtStart.size > 0 ? { status: "selected", ids: selectedAtStart } : { status: "none" })
+                focus.set(
+                    selectedAtStart.size > 0
+                        ? { status: "selected", itemIds: selectedAtStart, connectionIds: emptySet() }
+                        : { status: "none" },
+                )
                 dragAction.set({ action: "select", selectedAtStart })
             }
         })
@@ -83,7 +88,7 @@ export function boardDragHandler({
                         const toBeSelected = new Set(overlapping.map((i) => i.id).concat([...da.selectedAtStart]))
 
                         toBeSelected.size > 0
-                            ? focus.set({ status: "selected", ids: toBeSelected })
+                            ? focus.set({ status: "selected", itemIds: toBeSelected, connectionIds: emptySet() })
                             : focus.set({ status: "none" })
                     } else if (da.action === "pan") {
                         const s = start.get()

--- a/frontend/src/board/board-drag.ts
+++ b/frontend/src/board/board-drag.ts
@@ -1,18 +1,19 @@
-import { BoardCoordinateHelper, BoardCoordinates } from "./board-coordinates"
-import { Board, Item, Container, Point } from "../../../common/src/domain"
-import * as L from "lonna"
-import { DND_GHOST_HIDING_IMAGE } from "./item-drag"
-import { BoardFocus, getSelectedItemIds } from "./board-focus"
-import { Rect, overlaps, rectFromPoints, Coordinates, containedBy } from "../../../common/src/geometry"
-import * as _ from "lodash"
 import { componentScope } from "harmaja"
-import { Tool, ToolController } from "./tool-selection"
-import { Dispatch } from "../store/server-connection"
-import { drawConnectionHandler } from "./item-connect"
+import * as _ from "lodash"
+import * as L from "lonna"
+import { connectionRect } from "../../../common/src/connection-utils"
+import { Board, Point } from "../../../common/src/domain"
+import { containedBy, overlaps, Rect, rectFromPoints } from "../../../common/src/geometry"
 import { emptySet } from "../../../common/src/sets"
+import { Dispatch } from "../store/server-connection"
+import { BoardCoordinateHelper, BoardCoordinates } from "./board-coordinates"
+import { isAnythingSelected, BoardFocus, getSelectedItemIds, noFocus, getSelectedConnectionIds } from "./board-focus"
+import { drawConnectionHandler } from "./item-connect"
+import { DND_GHOST_HIDING_IMAGE } from "./item-drag"
+import { ToolController } from "./tool-selection"
 
 export type DragAction =
-    | { action: "select"; selectedAtStart: Set<string> }
+    | { action: "select"; selectedAtStart: BoardFocus }
     | { action: "pan" }
     | { action: "none" }
     | { action: "connect"; startPos: Point }
@@ -58,17 +59,21 @@ export function boardDragHandler({
             } else if (!shouldDragSelect) {
                 dragAction.set({ action: "pan" })
             } else {
-                let selectedAtStart = e.shiftKey ? getSelectedItemIds(focus.get()) : new Set<string>()
+                const f = focus.get()
+                const selectedAtStart = e.shiftKey ? f : noFocus
+                const anySelected = isAnythingSelected(selectedAtStart)
                 focus.set(
-                    selectedAtStart.size > 0
-                        ? { status: "selected", itemIds: selectedAtStart, connectionIds: emptySet() }
-                        : { status: "none" },
+                    anySelected
+                        ? {
+                              status: "selected",
+                              itemIds: getSelectedItemIds(selectedAtStart),
+                              connectionIds: getSelectedConnectionIds(selectedAtStart),
+                          }
+                        : noFocus,
                 )
                 dragAction.set({ action: "select", selectedAtStart })
             }
         })
-
-        const itemsList = L.view(L.view(board, "items"), Object.values)
 
         el.addEventListener(
             "drag",
@@ -80,16 +85,25 @@ export function boardDragHandler({
                     if (da.action === "select") {
                         const bounds = rect.get()!
                         const startPoint = start.get()!
-                        // Do not select container if drag originates from within container
-                        const overlapping = itemsList
-                            .get()
-                            .filter((i) => overlaps(i, bounds) && !containedBy(startPoint, i))
+                        const b = board.get()
 
-                        const toBeSelected = new Set(overlapping.map((i) => i.id).concat([...da.selectedAtStart]))
+                        const itemIds = new Set([
+                            ...Object.values(b.items)
+                                .filter((i) => overlaps(i, bounds) && !containedBy(startPoint, i)) // Do not select container if drag originates from within container
+                                .map((i) => i.id),
+                            ...getSelectedItemIds(da.selectedAtStart),
+                        ])
 
-                        toBeSelected.size > 0
-                            ? focus.set({ status: "selected", itemIds: toBeSelected, connectionIds: emptySet() })
-                            : focus.set({ status: "none" })
+                        const connectionIds = new Set([
+                            ...b.connections.filter((c) => overlaps(connectionRect(b)(c), bounds)).map((i) => i.id),
+                            ...getSelectedConnectionIds(da.selectedAtStart),
+                        ])
+
+                        console.log(connectionIds)
+
+                        itemIds.size + connectionIds.size > 0
+                            ? focus.set({ status: "selected", itemIds, connectionIds })
+                            : focus.set(noFocus)
                     } else if (da.action === "pan") {
                         const s = start.get()
                         const c = current.get()

--- a/frontend/src/board/board-focus.ts
+++ b/frontend/src/board/board-focus.ts
@@ -45,6 +45,9 @@ export const getSelectedItem = (b: Board) => (f: BoardFocus): Item | null => {
     return getSelectedItems(b)(f)[0] || null
 }
 
+export const isAnythingSelected = (f: BoardFocus) =>
+    getSelectedConnectionIds(f).size > 0 || getSelectedItemIds(f).size > 0
+
 export function removeFromSelection(
     selection: BoardFocus,
     toRemoveItems: Set<Id>,
@@ -56,17 +59,17 @@ export function removeFromSelection(
         case "connection-adding":
             return selection
         case "editing":
-            return toRemoveItems.has(selection.itemId) ? { status: "none" } : selection
+            return toRemoveItems.has(selection.itemId) ? noFocus : selection
         case "dragging":
             selection = { ...selection, itemIds: difference(selection.itemIds, toRemoveItems) }
-            return selection.itemIds.size > 0 ? selection : { status: "none" }
+            return selection.itemIds.size > 0 ? selection : noFocus
         case "selected":
             selection = {
                 ...selection,
                 itemIds: difference(selection.itemIds, toRemoveItems),
                 connectionIds: difference(selection.connectionIds, toRemoveConnections),
             }
-            return selection.itemIds.size + selection.connectionIds.size > 0 ? selection : { status: "none" }
+            return selection.itemIds.size + selection.connectionIds.size > 0 ? selection : noFocus
     }
 }
 
@@ -79,3 +82,5 @@ export function removeNonExistingFromSelection(
     const toRemoveConnections = difference(getSelectedConnectionIds(selection), existingConnectionIds)
     return removeFromSelection(selection, toRemoveItems, toRemoveConnections)
 }
+
+export const noFocus: BoardFocus = { status: "none" }

--- a/frontend/src/board/board-focus.ts
+++ b/frontend/src/board/board-focus.ts
@@ -5,7 +5,7 @@ import { difference, emptySet } from "../../../common/src/sets"
 export type BoardFocus =
     | { status: "none" }
     | { status: "selected"; itemIds: Set<Id>; connectionIds: Set<Id> }
-    | { status: "dragging"; itemIds: Set<Id> }
+    | { status: "dragging"; itemIds: Set<Id>; connectionIds: Set<Id> }
     | { status: "editing"; itemId: Id }
     | { status: "adding"; element: HarmajaChild; item: Item }
     | { status: "connection-adding" }
@@ -30,8 +30,8 @@ export function getSelectedConnectionIds(f: BoardFocus): Set<Id> {
         case "adding":
         case "editing":
         case "connection-adding":
-        case "dragging":
             return emptySet()
+        case "dragging":
         case "selected":
             return f.connectionIds
     }
@@ -61,8 +61,6 @@ export function removeFromSelection(
         case "editing":
             return toRemoveItems.has(selection.itemId) ? noFocus : selection
         case "dragging":
-            selection = { ...selection, itemIds: difference(selection.itemIds, toRemoveItems) }
-            return selection.itemIds.size > 0 ? selection : noFocus
         case "selected":
             selection = {
                 ...selection,

--- a/frontend/src/board/board-focus.ts
+++ b/frontend/src/board/board-focus.ts
@@ -1,14 +1,12 @@
-import { HarmajaChild, HarmajaOutput } from "harmaja"
+import { HarmajaChild } from "harmaja"
 import { Board, findItem, Id, Item } from "../../../common/src/domain"
-import { getItem } from "../../../common/src/domain"
-import { difference } from "../../../common/src/sets"
+import { difference, emptySet } from "../../../common/src/sets"
 
 export type BoardFocus =
     | { status: "none" }
-    | { status: "selected"; ids: Set<Id> }
-    | { status: "dragging"; ids: Set<Id> }
-    | { status: "connection-selected"; ids: Set<Id> }
-    | { status: "editing"; id: Id }
+    | { status: "selected"; itemIds: Set<Id>; connectionIds: Set<Id> }
+    | { status: "dragging"; itemIds: Set<Id> }
+    | { status: "editing"; itemId: Id }
     | { status: "adding"; element: HarmajaChild; item: Item }
     | { status: "connection-adding" }
 
@@ -17,13 +15,25 @@ export function getSelectedItemIds(f: BoardFocus): Set<Id> {
         case "none":
         case "adding":
         case "connection-adding":
-        case "connection-selected":
-            return new Set()
+            return emptySet()
         case "editing":
-            return new Set([f.id])
+            return new Set([f.itemId])
         case "selected":
         case "dragging":
-            return f.ids
+            return f.itemIds
+    }
+}
+
+export function getSelectedConnectionIds(f: BoardFocus): Set<Id> {
+    switch (f.status) {
+        case "none":
+        case "adding":
+        case "editing":
+        case "connection-adding":
+        case "dragging":
+            return emptySet()
+        case "selected":
+            return f.connectionIds
     }
 }
 
@@ -35,23 +45,37 @@ export const getSelectedItem = (b: Board) => (f: BoardFocus): Item | null => {
     return getSelectedItems(b)(f)[0] || null
 }
 
-export function removeFromSelection(selection: BoardFocus, toRemove: Set<Id>): BoardFocus {
+export function removeFromSelection(
+    selection: BoardFocus,
+    toRemoveItems: Set<Id>,
+    toRemoveConnections: Set<Id>,
+): BoardFocus {
     switch (selection.status) {
         case "adding":
         case "none":
         case "connection-adding":
             return selection
         case "editing":
-            return toRemove.has(selection.id) ? { status: "none" } : selection
+            return toRemoveItems.has(selection.itemId) ? { status: "none" } : selection
         case "dragging":
-        case "connection-selected":
+            selection = { ...selection, itemIds: difference(selection.itemIds, toRemoveItems) }
+            return selection.itemIds.size > 0 ? selection : { status: "none" }
         case "selected":
-            selection = { ...selection, ids: difference(selection.ids, toRemove) }
-            return selection.ids.size > 0 ? selection : { status: "none" }
+            selection = {
+                ...selection,
+                itemIds: difference(selection.itemIds, toRemoveItems),
+                connectionIds: difference(selection.connectionIds, toRemoveConnections),
+            }
+            return selection.itemIds.size + selection.connectionIds.size > 0 ? selection : { status: "none" }
     }
 }
 
-export function removeNonExistingFromSelection(selection: BoardFocus, existing: Set<Id>): BoardFocus {
-    const nonExistent = difference(getSelectedItemIds(selection), existing)
-    return removeFromSelection(selection, nonExistent)
+export function removeNonExistingFromSelection(
+    selection: BoardFocus,
+    existingItemIds: Set<Id>,
+    existingConnectionIds: Set<Id>,
+): BoardFocus {
+    const toRemoveItems = difference(getSelectedItemIds(selection), existingItemIds)
+    const toRemoveConnections = difference(getSelectedConnectionIds(selection), existingConnectionIds)
+    return removeFromSelection(selection, toRemoveItems, toRemoveConnections)
 }

--- a/frontend/src/board/contextmenu/ContextMenuView.tsx
+++ b/frontend/src/board/contextmenu/ContextMenuView.tsx
@@ -35,13 +35,12 @@ export const ContextMenuView = ({
             case "none":
             case "adding":
             case "connection-adding":
-            case "connection-selected":
             case "dragging":
                 return []
             case "editing":
-                return [f.id]
+                return [f.itemId]
             case "selected":
-                return [...f.ids]
+                return [...f.itemIds] // TODO: consider connections for context menu
         }
     }
 

--- a/frontend/src/board/item-connect.ts
+++ b/frontend/src/board/item-connect.ts
@@ -20,6 +20,7 @@ import { BoardCoordinateHelper } from "./board-coordinates"
 import { BoardFocus } from "./board-focus"
 import { centerPoint, containedBy } from "../../../common/src/geometry"
 import { ToolController } from "./tool-selection"
+import { emptySet } from "../../../common/src/sets"
 
 export const DND_GHOST_HIDING_IMAGE = new Image()
 // https://png-pixel.com/
@@ -122,7 +123,9 @@ export function drawConnectionHandler(
 
     const endDrag = () => {
         focus.set(
-            localConnection ? { status: "connection-selected", ids: new Set(localConnection.id) } : { status: "none" },
+            localConnection
+                ? { status: "selected", itemIds: emptySet(), connectionIds: new Set(localConnection.id) }
+                : { status: "none" },
         )
         localConnection = null
     }

--- a/frontend/src/board/item-connect.ts
+++ b/frontend/src/board/item-connect.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../common/src/domain"
 import { Dispatch } from "../store/board-store"
 import { BoardCoordinateHelper } from "./board-coordinates"
-import { BoardFocus } from "./board-focus"
+import { BoardFocus, noFocus } from "./board-focus"
 import { centerPoint, containedBy } from "../../../common/src/geometry"
 import { ToolController } from "./tool-selection"
 import { emptySet } from "../../../common/src/sets"
@@ -125,7 +125,7 @@ export function drawConnectionHandler(
         focus.set(
             localConnection
                 ? { status: "selected", itemIds: emptySet(), connectionIds: new Set(localConnection.id) }
-                : { status: "none" },
+                : noFocus,
         )
         localConnection = null
     }

--- a/frontend/src/board/item-cut-copy-paste.ts
+++ b/frontend/src/board/item-cut-copy-paste.ts
@@ -51,7 +51,6 @@ export function findSelectedItemsAndConnections(currentFocus: BoardFocus, curren
             from: detachEndPointIfItemNotFound(c.from, recursiveIds, currentBoard),
             to: detachEndPointIfItemNotFound(c.to, recursiveIds, currentBoard),
         }))
-    console.log({ items, connections })
     return { items, connections }
 }
 

--- a/frontend/src/board/item-cut-copy-paste.ts
+++ b/frontend/src/board/item-cut-copy-paste.ts
@@ -21,6 +21,7 @@ import { Dispatch } from "../store/board-store"
 import { YELLOW } from "../../../common/src/colors"
 import { sanitizeHTML } from "../components/sanitizeHTML"
 import * as G from "../../../common/src/geometry"
+import { emptySet } from "../../../common/src/sets"
 
 const CLIPBOARD_EVENTS = ["cut", "copy", "paste"] as const
 
@@ -117,7 +118,8 @@ export function cutCopyPasteHandler(
         const currentBoard = board.get()
         switch (e.type) {
             case "cut": {
-                if (currentFocus.status !== "selected" || currentFocus.ids.size === 0) return
+                // TODO: support connections on clipboard as well
+                if (currentFocus.status !== "selected" || currentFocus.itemIds.size === 0) return
                 const clipboard = findSelectedItems(currentFocus, currentBoard)
                 dispatch({ action: "item.delete", boardId: currentBoard.id, itemIds: clipboard.items.map((i) => i.id) })
                 e.clipboardData!.setData("application/rboard", JSON.stringify(clipboard))
@@ -180,7 +182,11 @@ export function cutCopyPasteHandler(
                     const yDiff = Math.min(Math.max(currentCenter.y - yCenterOld, yDiffMin), yDiffMax)
                     const { toCreate, toSelect, connections } = makeCopies(clipboard, xDiff, yDiff)
                     dispatch({ action: "item.add", boardId: currentBoard.id, items: toCreate, connections })
-                    focus.set({ status: "selected", ids: new Set(toSelect.map((it) => it.id)) })
+                    focus.set({
+                        status: "selected",
+                        itemIds: new Set(toSelect.map((it) => it.id)),
+                        connectionIds: emptySet(),
+                    })
                     e.preventDefault()
                 }
                 break

--- a/frontend/src/board/item-cut-copy-paste.ts
+++ b/frontend/src/board/item-cut-copy-paste.ts
@@ -22,7 +22,7 @@ import { YELLOW } from "../../../common/src/colors"
 import { sanitizeHTML } from "../components/sanitizeHTML"
 import * as G from "../../../common/src/geometry"
 import { emptySet } from "../../../common/src/sets"
-import { resolveEndpoint } from "../../../common/src/connection-utils"
+import { connectionRect, resolveEndpoint } from "../../../common/src/connection-utils"
 
 const CLIPBOARD_EVENTS = ["cut", "copy", "paste"] as const
 
@@ -232,19 +232,4 @@ export function cutCopyPasteHandler(
             document.removeEventListener(eventType, clipboardEventHandler)
         })
     }
-}
-
-const connectionRect = (b: Board | Record<string, Item>) => (c: Connection): G.Rect => {
-    const start = resolveEndpoint(c.from, b)
-    const end = resolveEndpoint(c.to, b)
-    const allPoints = [start, ...c.controlPoints, end]
-    const minX = _.min(allPoints.map((p) => p.x))!
-    const maxX = _.max(allPoints.map((p) => p.x))!
-    const minY = _.min(allPoints.map((p) => p.y))!
-    const maxY = _.max(allPoints.map((p) => p.y))!
-    const x = minX
-    const y = minY
-    const width = maxX - minX
-    const height = maxY - minY
-    return { x, y, width, height }
 }

--- a/frontend/src/board/item-cut-copy-paste.ts
+++ b/frontend/src/board/item-cut-copy-paste.ts
@@ -16,12 +16,13 @@ import {
     getEndPointItemId,
 } from "../../../common/src/domain"
 import { BoardCoordinateHelper } from "./board-coordinates"
-import { BoardFocus, getSelectedItemIds } from "./board-focus"
+import { BoardFocus, getSelectedConnectionIds, getSelectedItemIds } from "./board-focus"
 import { Dispatch } from "../store/board-store"
 import { YELLOW } from "../../../common/src/colors"
 import { sanitizeHTML } from "../components/sanitizeHTML"
 import * as G from "../../../common/src/geometry"
 import { emptySet } from "../../../common/src/sets"
+import { resolveEndpoint } from "../../../common/src/connection-utils"
 
 const CLIPBOARD_EVENTS = ["cut", "copy", "paste"] as const
 
@@ -30,17 +31,36 @@ export type ItemsAndConnections = {
     connections: Connection[]
 }
 
-export function findSelectedItems(currentFocus: BoardFocus, currentBoard: Board): ItemsAndConnections {
-    const selectedIds = getSelectedItemIds(currentFocus)
-    const items = findItemsRecursively([...selectedIds], currentBoard)
+export function findSelectedItemsAndConnections(currentFocus: BoardFocus, currentBoard: Board): ItemsAndConnections {
+    const selectedItemIds = getSelectedItemIds(currentFocus)
+    const selectedConnectionIds = getSelectedConnectionIds(currentFocus)
+    const items = findItemsRecursively([...selectedItemIds], currentBoard)
     const recursiveIds = new Set(items.map((i) => i.id))
-    const connections = currentBoard.connections.filter((c) => {
-        // Include connections between these items and connections that have one end
-        // in these items and the other end not connected.
-        const ids = connectedIds(c)
-        return ids.length > 0 && !ids.some((id) => !recursiveIds.has(id))
-    })
+    const connections = currentBoard.connections
+        .filter((c) => {
+            if (selectedConnectionIds.has(c.id)) {
+                return true
+            }
+            // Include connections between these items and connections that have one end
+            // in these items and the other end not connected.
+            const ids = connectedIds(c)
+            return ids.length > 0 && !ids.some((id) => !recursiveIds.has(id))
+        })
+        .map((c) => ({
+            ...c,
+            from: detachEndPointIfItemNotFound(c.from, recursiveIds, currentBoard),
+            to: detachEndPointIfItemNotFound(c.to, recursiveIds, currentBoard),
+        }))
+    console.log({ items, connections })
     return { items, connections }
+}
+
+function detachEndPointIfItemNotFound(ep: ConnectionEndPoint, itemIds: Set<Id>, currentBoard: Board) {
+    if (isItemEndPoint(ep) && !itemIds.has(getEndPointItemId(ep))) {
+        const resolved = resolveEndpoint(ep, currentBoard)
+        return Point(resolved.x, resolved.y)
+    }
+    return ep
 }
 
 function connectedIds(connection: Connection) {
@@ -118,17 +138,21 @@ export function cutCopyPasteHandler(
         const currentBoard = board.get()
         switch (e.type) {
             case "cut": {
-                // TODO: support connections on clipboard as well
-                if (currentFocus.status !== "selected" || currentFocus.itemIds.size === 0) return
-                const clipboard = findSelectedItems(currentFocus, currentBoard)
-                dispatch({ action: "item.delete", boardId: currentBoard.id, itemIds: clipboard.items.map((i) => i.id) })
+                if (currentFocus.status !== "selected") return
+                const clipboard = findSelectedItemsAndConnections(currentFocus, currentBoard)
+                dispatch({
+                    action: "item.delete",
+                    boardId: currentBoard.id,
+                    itemIds: clipboard.items.map((i) => i.id),
+                    connectionIds: [...getSelectedConnectionIds(currentFocus)],
+                })
                 e.clipboardData!.setData("application/rboard", JSON.stringify(clipboard))
                 e.preventDefault()
                 break
             }
             case "copy": {
                 if (currentFocus.status !== "selected") return
-                const clipboard = findSelectedItems(currentFocus, currentBoard)
+                const clipboard = findSelectedItemsAndConnections(currentFocus, currentBoard)
                 e.clipboardData!.setData("application/rboard", JSON.stringify(clipboard))
                 e.preventDefault()
                 break
@@ -168,19 +192,24 @@ export function cutCopyPasteHandler(
                         return
                     }
                     const requiredMargin = BOARD_ITEM_BORDER_MARGIN
-                    const xDiffMin = -_.min(clipboard.items.map((i) => i.x))! + requiredMargin
-                    const yDiffMin = -_.min(clipboard.items.map((i) => i.y))! + requiredMargin
-                    const xDiffMax =
-                        board.get().width - _.max(clipboard.items.map((i) => i.x + i.width))! - requiredMargin
-                    const yDiffMax =
-                        board.get().height - _.max(clipboard.items.map((i) => i.y + i.height))! - requiredMargin
-                    const xCenterOld = _.sum(clipboard.items.map((i) => i.x + i.width / 2)) / clipboard.items.length
-                    const yCenterOld = _.sum(clipboard.items.map((i) => i.y + i.height / 2)) / clipboard.items.length
+                    const itemRecord = Object.fromEntries(clipboard.items.map((i) => [i.id, i]))
+                    const theItems = [...clipboard.items, ...clipboard.connections.map(connectionRect(itemRecord))]
+                    if (theItems.length === 0) {
+                        console.log("Empty clipboard")
+                        return
+                    }
+                    const xDiffMin = -_.min(theItems.map((i) => i.x))! + requiredMargin
+                    const yDiffMin = -_.min(theItems.map((i) => i.y))! + requiredMargin
+                    const xDiffMax = board.get().width - _.max(theItems.map((i) => i.x + i.width))! - requiredMargin
+                    const yDiffMax = board.get().height - _.max(theItems.map((i) => i.y + i.height))! - requiredMargin
+                    const xCenterOld = _.sum(theItems.map((i) => i.x + i.width / 2)) / theItems.length
+                    const yCenterOld = _.sum(theItems.map((i) => i.y + i.height / 2)) / theItems.length
                     const currentCenter = coordinateHelper.currentBoardCoordinates.get()
 
                     const xDiff = Math.min(Math.max(currentCenter.x - xCenterOld, xDiffMin), xDiffMax)
                     const yDiff = Math.min(Math.max(currentCenter.y - yCenterOld, yDiffMin), yDiffMax)
                     const { toCreate, toSelect, connections } = makeCopies(clipboard, xDiff, yDiff)
+
                     dispatch({ action: "item.add", boardId: currentBoard.id, items: toCreate, connections })
                     focus.set({
                         status: "selected",
@@ -203,4 +232,19 @@ export function cutCopyPasteHandler(
             document.removeEventListener(eventType, clipboardEventHandler)
         })
     }
+}
+
+const connectionRect = (b: Board | Record<string, Item>) => (c: Connection): G.Rect => {
+    const start = resolveEndpoint(c.from, b)
+    const end = resolveEndpoint(c.to, b)
+    const allPoints = [start, ...c.controlPoints, end]
+    const minX = _.min(allPoints.map((p) => p.x))!
+    const maxX = _.max(allPoints.map((p) => p.x))!
+    const minY = _.min(allPoints.map((p) => p.y))!
+    const maxY = _.max(allPoints.map((p) => p.y))!
+    const x = minX
+    const y = minY
+    const width = maxX - minX
+    const height = maxY - minY
+    return { x, y, width, height }
 }

--- a/frontend/src/board/item-delete.ts
+++ b/frontend/src/board/item-delete.ts
@@ -8,13 +8,9 @@ export function itemDeleteHandler(boardId: Id, dispatch: Dispatch, focus: L.Prop
     installKeyboardShortcut(plainKey("Delete", "Backspace"), () => {
         const f = focus.get()
         const connectionIds = [...getSelectedConnectionIds(focus.get())]
-        if (connectionIds.length) {
-            dispatch({ action: "connection.delete", connectionId: connectionIds, boardId }) // TODO: make a new combined delete action
-        }
-
         const itemIds = [...getSelectedItemIds(focus.get())]
-        if (itemIds.length) {
-            dispatch({ action: "item.delete", boardId, itemIds })
+        if (itemIds.length || connectionIds.length) {
+            dispatch({ action: "item.delete", boardId, itemIds, connectionIds })
         }
     })
 }

--- a/frontend/src/board/item-delete.ts
+++ b/frontend/src/board/item-delete.ts
@@ -1,16 +1,15 @@
 import * as L from "lonna"
 import { Id } from "../../../common/src/domain"
 import { Dispatch } from "../store/board-store"
-import { BoardFocus, getSelectedItemIds } from "./board-focus"
+import { BoardFocus, getSelectedConnectionIds, getSelectedItemIds } from "./board-focus"
 import { installKeyboardShortcut, plainKey } from "./keyboard-shortcuts"
 
 export function itemDeleteHandler(boardId: Id, dispatch: Dispatch, focus: L.Property<BoardFocus>) {
     installKeyboardShortcut(plainKey("Delete", "Backspace"), () => {
         const f = focus.get()
-        if (f.status === "connection-selected") {
-            const ids = [...f.ids]
-            dispatch({ action: "connection.delete", connectionId: ids, boardId })
-            return
+        const connectionIds = [...getSelectedConnectionIds(focus.get())]
+        if (connectionIds.length) {
+            dispatch({ action: "connection.delete", connectionId: connectionIds, boardId }) // TODO: make a new combined delete action
         }
 
         const itemIds = [...getSelectedItemIds(focus.get())]

--- a/frontend/src/board/item-drag.ts
+++ b/frontend/src/board/item-drag.ts
@@ -4,6 +4,7 @@ import { getItem } from "../../../common/src/domain"
 import { BoardCoordinateHelper } from "./board-coordinates"
 import { BoardFocus, getSelectedItemIds } from "./board-focus"
 import { Coordinates } from "../../../common/src/geometry"
+import { emptySet } from "../../../common/src/sets"
 
 export const DND_GHOST_HIDING_IMAGE = new Image()
 // https://png-pixel.com/
@@ -36,13 +37,13 @@ export function onBoardItemDrag(
         e.stopPropagation()
         e.dataTransfer?.setDragImage(DND_GHOST_HIDING_IMAGE, 0, 0)
         if (f.status === "dragging") {
-            if (!f.ids.has(id)) {
-                focus.set({ status: "dragging", ids: new Set([id]) })
+            if (!f.itemIds.has(id)) {
+                focus.set({ status: "dragging", itemIds: new Set([id]) })
             }
-        } else if (f.status === "selected" && f.ids.has(id)) {
-            focus.set({ status: "dragging", ids: f.ids })
+        } else if (f.status === "selected" && f.itemIds.has(id)) {
+            focus.set({ status: "dragging", itemIds: f.itemIds })
         } else {
-            focus.set({ status: "dragging", ids: new Set([id]) })
+            focus.set({ status: "dragging", itemIds: new Set([id]) })
         }
 
         dragStart = e
@@ -67,7 +68,7 @@ export function onBoardItemDrag(
         const { x: xDiff, y: yDiff } = newPos
 
         const b = board.get()
-        const items = [...f.ids].map((id) => {
+        const items = [...f.itemIds].map((id) => {
             const current = b.items[id]
             const dragStartPosition = dragStartPositions[id]
             if (!current || !dragStartPosition) throw Error("Item not found: " + id)
@@ -87,11 +88,11 @@ export function onBoardItemDrag(
             }
             if (doOnDrop) {
                 const b = board.get()
-                const items = [...f.ids].map(getItem(b))
+                const items = [...f.itemIds].map(getItem(b))
                 doOnDrop(b, items)
             }
             currentPos = null
-            return { status: "selected", ids: f.ids }
+            return { status: "selected", itemIds: f.itemIds, connectionIds: emptySet() }
         })
     }
 

--- a/frontend/src/board/item-dragmove.ts
+++ b/frontend/src/board/item-dragmove.ts
@@ -53,8 +53,8 @@ export function itemDragToMove(
                         const container = maybeChangeContainer(current, b.items)
                         return { id: current.id, x, y, containerId: container ? container.id : undefined }
                     })
-
-                    dispatch({ action: "item.move", boardId: b.id, items: movedItems })
+                    // TODO: move connections
+                    dispatch({ action: "item.move", boardId: b.id, items: movedItems, connections: [] })
                 }
             },
             () => {

--- a/frontend/src/board/item-duplicate.ts
+++ b/frontend/src/board/item-duplicate.ts
@@ -3,13 +3,13 @@ import { Board } from "../../../common/src/domain"
 import { emptySet } from "../../../common/src/sets"
 import { Dispatch } from "../store/board-store"
 import { BoardFocus } from "./board-focus"
-import { findSelectedItems, makeCopies } from "./item-cut-copy-paste"
+import { findSelectedItemsAndConnections, makeCopies } from "./item-cut-copy-paste"
 import { controlKey, installKeyboardShortcut } from "./keyboard-shortcuts"
 
 export function itemDuplicateHandler(board: L.Property<Board>, dispatch: Dispatch, focus: L.Atom<BoardFocus>) {
     installKeyboardShortcut(controlKey("d"), () => {
         const currentBoard = board.get()
-        const itemsAndConnections = findSelectedItems(focus.get(), currentBoard)
+        const itemsAndConnections = findSelectedItemsAndConnections(focus.get(), currentBoard)
         const { toCreate, toSelect, connections } = makeCopies(itemsAndConnections, 1, 1)
         dispatch({ action: "item.add", boardId: currentBoard.id, items: toCreate, connections })
         focus.set({ status: "selected", itemIds: new Set(toSelect.map((it) => it.id)), connectionIds: emptySet() })

--- a/frontend/src/board/item-duplicate.ts
+++ b/frontend/src/board/item-duplicate.ts
@@ -1,8 +1,8 @@
-import { componentScope } from "harmaja"
 import * as L from "lonna"
 import { Board } from "../../../common/src/domain"
-import { BoardFocus } from "./board-focus"
+import { emptySet } from "../../../common/src/sets"
 import { Dispatch } from "../store/board-store"
+import { BoardFocus } from "./board-focus"
 import { findSelectedItems, makeCopies } from "./item-cut-copy-paste"
 import { controlKey, installKeyboardShortcut } from "./keyboard-shortcuts"
 
@@ -12,6 +12,6 @@ export function itemDuplicateHandler(board: L.Property<Board>, dispatch: Dispatc
         const itemsAndConnections = findSelectedItems(focus.get(), currentBoard)
         const { toCreate, toSelect, connections } = makeCopies(itemsAndConnections, 1, 1)
         dispatch({ action: "item.add", boardId: currentBoard.id, items: toCreate, connections })
-        focus.set({ status: "selected", ids: new Set(toSelect.map((it) => it.id)) })
+        focus.set({ status: "selected", itemIds: new Set(toSelect.map((it) => it.id)), connectionIds: emptySet() })
     })
 }

--- a/frontend/src/board/item-move-with-arrow-keys.ts
+++ b/frontend/src/board/item-move-with-arrow-keys.ts
@@ -1,5 +1,5 @@
 import * as L from "lonna"
-import { connectionRect } from "../../../common/src/connection-utils"
+import { connectionRect, resolveEndpoint } from "../../../common/src/connection-utils"
 import { Board, BOARD_ITEM_BORDER_MARGIN } from "../../../common/src/domain"
 import { Rect } from "../../../common/src/geometry"
 import { Dispatch } from "../store/board-store"
@@ -46,7 +46,8 @@ export function itemMoveWithArrowKeysHandler(board: L.Property<Board>, dispatch:
                     const movedRect = moveItem(currentBoard, rect, e.key, e.shiftKey, e.altKey)
                     const xDiff = movedRect.x - rect.x
                     const yDiff = movedRect.y - rect.y
-                    return { id: connection.id, xDiff, yDiff }
+                    const startPoint = resolveEndpoint(connection.from, currentBoard)
+                    return { id: connection.id, x: startPoint.x + xDiff, y: startPoint.y + yDiff }
                 })
                 dispatch({
                     action: "item.move",

--- a/frontend/src/board/item-move-with-arrow-keys.ts
+++ b/frontend/src/board/item-move-with-arrow-keys.ts
@@ -3,7 +3,7 @@ import * as L from "lonna"
 import { Board, BOARD_ITEM_BORDER_MARGIN, Item } from "../../../common/src/domain"
 import { BoardFocus } from "./board-focus"
 import { Dispatch } from "../store/board-store"
-import { findSelectedItems } from "./item-cut-copy-paste"
+import { findSelectedItemsAndConnections } from "./item-cut-copy-paste"
 import { installKeyboardShortcut } from "./keyboard-shortcuts"
 
 function updatePosition(board: Board, item: Item, dx: number, dy: number): Item {
@@ -35,7 +35,7 @@ export function itemMoveWithArrowKeysHandler(board: L.Property<Board>, dispatch:
         (e) => ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key),
         (e) => {
             const currentBoard = board.get()
-            const itemsAndConnections = findSelectedItems(focus.get(), currentBoard)
+            const itemsAndConnections = findSelectedItemsAndConnections(focus.get(), currentBoard)
             if (itemsAndConnections.items.length > 0 || itemsAndConnections.connections.length > 0) {
                 const movedItems = itemsAndConnections.items.map((item) =>
                     moveItem(currentBoard, item, e.key, e.shiftKey, e.altKey),

--- a/frontend/src/board/item-move-with-arrow-keys.ts
+++ b/frontend/src/board/item-move-with-arrow-keys.ts
@@ -1,12 +1,13 @@
-import { componentScope } from "harmaja"
 import * as L from "lonna"
-import { Board, BOARD_ITEM_BORDER_MARGIN, Item } from "../../../common/src/domain"
-import { BoardFocus } from "./board-focus"
+import { connectionRect } from "../../../common/src/connection-utils"
+import { Board, BOARD_ITEM_BORDER_MARGIN } from "../../../common/src/domain"
+import { Rect } from "../../../common/src/geometry"
 import { Dispatch } from "../store/board-store"
+import { BoardFocus } from "./board-focus"
 import { findSelectedItemsAndConnections } from "./item-cut-copy-paste"
 import { installKeyboardShortcut } from "./keyboard-shortcuts"
 
-function updatePosition(board: Board, item: Item, dx: number, dy: number): Item {
+function updatePosition<T extends Rect>(board: Board, item: T, dx: number, dy: number): T {
     const margin = BOARD_ITEM_BORDER_MARGIN
     return {
         ...item,
@@ -15,7 +16,7 @@ function updatePosition(board: Board, item: Item, dx: number, dy: number): Item 
     }
 }
 
-function moveItem(board: Board, item: Item, key: string, shiftKey: boolean, altKey: boolean): Item {
+function moveItem<T extends Rect>(board: Board, item: T, key: string, shiftKey: boolean, altKey: boolean): T {
     const stepSize = shiftKey ? 10 : altKey ? 0.1 : 1
     switch (key) {
         case "ArrowLeft":
@@ -40,7 +41,19 @@ export function itemMoveWithArrowKeysHandler(board: L.Property<Board>, dispatch:
                 const movedItems = itemsAndConnections.items.map((item) =>
                     moveItem(currentBoard, item, e.key, e.shiftKey, e.altKey),
                 )
-                dispatch({ action: "item.move", boardId: currentBoard.id, items: movedItems })
+                const movedConnections = itemsAndConnections.connections.map((connection) => {
+                    const rect = connectionRect(currentBoard)(connection)
+                    const movedRect = moveItem(currentBoard, rect, e.key, e.shiftKey, e.altKey)
+                    const xDiff = movedRect.x - rect.x
+                    const yDiff = movedRect.y - rect.y
+                    return { id: connection.id, xDiff, yDiff }
+                })
+                dispatch({
+                    action: "item.move",
+                    boardId: currentBoard.id,
+                    items: movedItems,
+                    connections: movedConnections,
+                })
             }
         },
     )

--- a/frontend/src/board/item-select-all.ts
+++ b/frontend/src/board/item-select-all.ts
@@ -5,6 +5,10 @@ import { controlKey, installKeyboardShortcut } from "./keyboard-shortcuts"
 
 export function itemSelectAllHandler(board: L.Property<Board>, focus: L.Atom<BoardFocus>) {
     installKeyboardShortcut(controlKey("a"), () =>
-        focus.set({ status: "selected", ids: new Set(Object.keys(board.get().items)) }),
+        focus.set({
+            status: "selected",
+            itemIds: new Set(Object.keys(board.get().items)),
+            connectionIds: new Set(board.get().connections.map((c) => c.id)),
+        }),
     )
 }

--- a/frontend/src/board/synchronize-focus-with-server.ts
+++ b/frontend/src/board/synchronize-focus-with-server.ts
@@ -2,7 +2,13 @@ import * as L from "lonna"
 import * as _ from "lodash"
 import { Board, Id, ItemLocks } from "../../../common/src/domain"
 import { Dispatch } from "../store/board-store"
-import { BoardFocus, getSelectedItemIds, removeFromSelection, removeNonExistingFromSelection } from "./board-focus"
+import {
+    BoardFocus,
+    getSelectedItemIds,
+    noFocus,
+    removeFromSelection,
+    removeNonExistingFromSelection,
+} from "./board-focus"
 import { componentScope } from "harmaja"
 import { emptySet } from "../../../common/src/sets"
 
@@ -45,14 +51,14 @@ export function synchronizeFocusWithServer(
 
     // selection where illegal (locked) items are removed
     const resolvedFocus = events.pipe(
-        L.scan({ status: "none" } as BoardFocus, (currentFocus, event) => {
+        L.scan(noFocus, (currentFocus, event) => {
             return narrowFocus("status" in event ? event : currentFocus, circumstances.get())
         }),
         L.skipDuplicates<BoardFocus>(_.isEqual, componentScope()),
     )
 
     function narrowFocus(focus: BoardFocus, { locks, sessionId: sessionId, board }: CircumStances): BoardFocus {
-        if (!sessionId) return { status: "none" }
+        if (!sessionId) return noFocus
         // TODO consider selected connection in locking as well maybe
         const itemsWhereSomeoneElseHasLock = new Set(Object.keys(locks).filter((itemId) => locks[itemId] !== sessionId))
         const nonLocked = removeFromSelection(focus, itemsWhereSomeoneElseHasLock, emptySet())


### PR DESCRIPTION
Allow selection of connections along items, and handling this heterogenous selection in different cases.

- [x] Copy-cut-paste
- [x] Combine delete into a single operation
- [x] Move with keyboard
- [x] Allow drag
- [x] Include connections in drag selections
- [x] Delete