### PR TITLE
Perftester exploration

### DIFF
--- a/frontend/src/store/board-store.ts
+++ b/frontend/src/store/board-store.ts
@@ -516,7 +516,7 @@ export function sessionState2UserInfo(state: UserSessionState): EventUserInfo {
         return {
             userType: "authenticated",
             email: state.email,
-            nickname: state.nickname,
+            nickname: state.nickname!,
             name: state.name,
             userId: state.userId,
         }

--- a/perf-tester/package.json
+++ b/perf-tester/package.json
@@ -15,7 +15,7 @@
     "harmaja": "^0.24",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
-    "lonna": "^0.12.1",
+    "lonna": "^0.12.2",
     "material-design-icons-iconfont": "^6.1.0",
     "md5": "^2.3.0",
     "node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5553,13 +5553,6 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-lonna@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/lonna/-/lonna-0.12.1.tgz#1e91753df227bf342ccb87ac64f92803affe1770"
-  integrity sha512-BS0pHNKGS2xOx4tEx8gWMRamwFZLstXMi+LT5nv/+HNSkGl8gEBWVgvrfO9biMlUBY7p4wbsFgm/zM14fa33Zg==
-  dependencies:
-    optics-ts "^1.2.0"
-
 lonna@^0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/lonna/-/lonna-0.12.2.tgz#b99ada89aeea037afc9c0abdb91adef431e2e1c5"


### PR DESCRIPTION
```
commit ac4d19954a8837717e18101851a849c8685c7764 (HEAD -> perftester-exploration, origin/perftester-exploration)
Author: Jussi Saurio <jussi.saurio@gmail.com>
Date:   Sun Oct 1 20:32:19 2023 +0300

    Server-connection: sort folded events in order of serial number
    
    This way, at the very least, the client's local board's serial
    number is always at least as high as the highest serial number in
    any incoming event, and doesn't ever decrease.

commit cedf13a0629a369fe83c2f93ac3cf32e07b72646
Author: Jussi Saurio <jussi.saurio@gmail.com>
Date:   Sun Oct 1 20:28:00 2023 +0300

    Perf-tester: add perf testers that type into notes
    
    - Use BoardStore() for perf-testers for a more realistic
      simulation of users sending events via the UI: the events
      are queued, folded etc. as normal.
    - Running perf tests with this setup yielded a big number of
      'Serial skip' warnings in the UI. After an investigation, I've
      simply added a note about not being able to guarantee sequentiality
      of events when folding is used on server-sent actions.
```