### PR TITLE
Add a small padding to text inside square and rectangle notes

### DIFF
--- a/frontend/src/board/ItemView.tsx
+++ b/frontend/src/board/ItemView.tsx
@@ -96,8 +96,16 @@ export const ItemView = ({
     )
 
     function itemPadding(i: Item) {
+        if (i.type != "note") return undefined
+
         const shape = getItemShape(i)
-        return shape == "diamond" ? `${i.width / 4}em` : shape == "round" ? `${i.width / 8}em` : undefined
+        return shape == "diamond"
+            ? `${i.width / 4}em`
+            : shape == "round"
+            ? `${i.width / 8}em`
+            : shape == "square" || shape == "rect"
+            ? `${(i.fontSize || 1) / 3}em`
+            : undefined
     }
     const shape = L.view(item, getItemShape)
 


### PR DESCRIPTION
The purpose is to make text aligned to the edge or corner of a note easier to read, as it's not too close to the edge/corner.

The padding is relative to font size.
    
For items other than notes keep the existing style at this point.