### PR TITLE
Links in collaborative editor

### DIFF
--- a/frontend/src/board/CollaborativeTextView.tsx
+++ b/frontend/src/board/CollaborativeTextView.tsx
@@ -6,21 +6,21 @@ import { QuillBinding } from "y-quill"
 import {
     AccessLevel,
     Board,
+    TextItem,
     canWrite,
     getAlign,
     getHorizontalAlign,
     getItemBackground,
-    TextItem,
 } from "../../../common/src/domain"
-import { Dispatch } from "../store/board-store"
 import { CRDTStore } from "../store/crdt-store"
+import { getAlignItems } from "./ItemView"
 import { BoardFocus } from "./board-focus"
 import { contrastingColor } from "./contrasting-color"
-import { getAlignItems } from "./ItemView"
-import { ToolController } from "./tool-selection"
 import { preventDoubleClick } from "./double-click"
+import PasteLinkOverText from "./quillPasteLinkOverText"
 
 Quill.register("modules/cursors", QuillCursors)
+Quill.register("modules/pasteLinkOverText", PasteLinkOverText)
 
 interface CollaborativeTextViewProps {
     item: L.Property<TextItem>
@@ -56,6 +56,7 @@ export function CollaborativeTextView({
             modules: {
                 cursors: true,
                 toolbar: false,
+                pasteLinkOverText: true,
                 history: {
                     userOnly: true, // Local undo shouldn't undo changes from remote users
                 },

--- a/frontend/src/board/CollaborativeTextView.tsx
+++ b/frontend/src/board/CollaborativeTextView.tsx
@@ -18,9 +18,11 @@ import { BoardFocus } from "./board-focus"
 import { contrastingColor } from "./contrasting-color"
 import { preventDoubleClick } from "./double-click"
 import PasteLinkOverText from "./quillPasteLinkOverText"
+import ClickableLink from "./quillClickableLink"
 
 Quill.register("modules/cursors", QuillCursors)
 Quill.register("modules/pasteLinkOverText", PasteLinkOverText)
+Quill.register(ClickableLink)
 
 interface CollaborativeTextViewProps {
     item: L.Property<TextItem>

--- a/frontend/src/board/quillClickableLink.ts
+++ b/frontend/src/board/quillClickableLink.ts
@@ -1,0 +1,15 @@
+import Quill from "quill"
+var Link = Quill.import("formats/link")
+
+export default class ClickableLink extends Link {
+    static create(href: any) {
+        let node = super.create(href) as HTMLAnchorElement
+        node.title = href
+        node.addEventListener("click", (e) => {
+            e.stopPropagation()
+            e.preventDefault()
+            window.open(href, "_blank")
+        })
+        return node
+    }
+}

--- a/frontend/src/board/quillPasteLinkOverText.ts
+++ b/frontend/src/board/quillPasteLinkOverText.ts
@@ -1,30 +1,18 @@
 import Quill from "quill"
 import { isURL } from "../components/sanitizeHTML"
 
-declare global {
-    interface Window {
-        Quill?: typeof Quill
-    }
-}
-
 export default class PasteLinkOverText {
-    quill: Quill
-
     constructor(quill: Quill) {
-        this.quill = quill
-        this.registerPasteListener()
-    }
-    registerPasteListener() {
-        this.quill.clipboard.addMatcher(Node.TEXT_NODE, (node, delta) => {
+        quill.clipboard.addMatcher(Node.TEXT_NODE, (node, delta) => {
             if (typeof node.data !== "string") {
                 return undefined as any // This is how it was written
             }
 
             const url = node.data
             if (isURL(url)) {
-                const sel = (this.quill as any).selection.savedRange as { index: number; length: number } | null
+                const sel = (quill as any).selection.savedRange as { index: number; length: number } | null
                 if (sel && sel.length > 0) {
-                    const existing = this.quill.getContents(sel.index, sel.length)
+                    const existing = quill.getContents(sel.index, sel.length)
                     if (existing.ops.length === 1 && typeof existing.ops[0].insert === "string") {
                         const existingText = existing.ops[0].insert
                         delta.ops = [{ insert: existingText, attributes: { link: url } }]
@@ -37,8 +25,4 @@ export default class PasteLinkOverText {
             return delta
         })
     }
-}
-
-if (window != null && window.Quill) {
-    window.Quill.register("modules/pasteLinkOverText", PasteLinkOverText)
 }

--- a/frontend/src/board/quillPasteLinkOverText.ts
+++ b/frontend/src/board/quillPasteLinkOverText.ts
@@ -1,0 +1,44 @@
+import Quill from "quill"
+import { isURL } from "../components/sanitizeHTML"
+
+declare global {
+    interface Window {
+        Quill?: typeof Quill
+    }
+}
+
+export default class PasteLinkOverText {
+    quill: Quill
+
+    constructor(quill: Quill) {
+        this.quill = quill
+        this.registerPasteListener()
+    }
+    registerPasteListener() {
+        this.quill.clipboard.addMatcher(Node.TEXT_NODE, (node, delta) => {
+            if (typeof node.data !== "string") {
+                return undefined as any // This is how it was written
+            }
+
+            const url = node.data
+            if (isURL(url)) {
+                const sel = (this.quill as any).selection.savedRange as { index: number; length: number } | null
+                if (sel && sel.length > 0) {
+                    const existing = this.quill.getContents(sel.index, sel.length)
+                    if (existing.ops.length === 1 && typeof existing.ops[0].insert === "string") {
+                        const existingText = existing.ops[0].insert
+                        delta.ops = [{ insert: existingText, attributes: { link: url } }]
+                    }
+                } else {
+                    delta.ops = [{ insert: url, attributes: { link: url } }]
+                }
+            }
+
+            return delta
+        })
+    }
+}
+
+if (window != null && window.Quill) {
+    window.Quill.register("modules/pasteLinkOverText", PasteLinkOverText)
+}


### PR DESCRIPTION
- [ ] Pasting a link to the Quill editor, either standalone or over existing text, should create an anchor element
- [ ] Make links clickable
- [ ] Make links editable (optional)