### PR TITLE
create and update item using API without container

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,19 @@ This endpoint always requires the API_TOKEN header.
 
 ### POST /api/v1/board/:boardId/item
 
-Creates a new item on given board. If you want to add the item onto a specific area/container element on the board, you can
-find the id of the container by inspecting with your browser.
+Creates a new item on given board.
 
 Payload:
 
 ```js
 {
+    "x": "x position of the note",
+    "y": "y position of the note",
     "type": "note",
     "text": "text on note",
-    "container": "container element text or id",
-    "color": "hexadecimal color code"
+    "color": "hexadecimal color code",
+    "width": "width of the note",
+    "height": "height of the note"
 }
 ```
 
@@ -165,13 +167,19 @@ Payload:
 
 ```js
 {
+    "x": "x position of the note",
+    "y": "y position of the note",
     "type": "note",
     "text": "text on note",
-    "container": "container element text or id",
     "color": "hexadecimal color code",
+    "width": "width of the note",
+    "height": "height of the note",
+    "replaceXIfExists": boolean,         // Override x if item with this id exists. Defaults to false.
+    "replaceYIfExists": boolean,         // Override y if item with this id exists. Defaults to false.
     "replaceTextIfExists": boolean,      // Override text if item with this id exists. Defaults to false.
     "replaceColorIfExists": boolean,     // Override color if item with this id exists. Defaults to false.
-    "replaceContainerIfExists": boolean, // Override container in item with this id exists. Defaults to true.
+    "replaceWidthIfExists": boolean,     // Override width if item with this id exists. Defaults to false.
+    "replaceHeightIfExists": boolean     // Override height if item with this id exists. Defaults to false.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ This endpoint always requires the API_TOKEN header.
 
 ### POST /api/v1/board/:boardId/item
 
-Creates a new item on given board.
+Creates a new item on given board. If you want to add the item onto a specific area/container element on the board, you can
+find the id of the container by inspecting with your browser.
 
 Payload:
 
@@ -143,6 +144,7 @@ Payload:
     "y": "y position of the note",
     "type": "note",
     "text": "text on note",
+    "container": "container element text or id",
     "color": "hexadecimal color code",
     "width": "width of the note",
     "height": "height of the note"
@@ -171,6 +173,7 @@ Payload:
     "y": "y position of the note",
     "type": "note",
     "text": "text on note",
+    "container": "container element text or id",
     "color": "hexadecimal color code",
     "width": "width of the note",
     "height": "height of the note",
@@ -178,6 +181,7 @@ Payload:
     "replaceYIfExists": boolean,         // Override y if item with this id exists. Defaults to false.
     "replaceTextIfExists": boolean,      // Override text if item with this id exists. Defaults to false.
     "replaceColorIfExists": boolean,     // Override color if item with this id exists. Defaults to false.
+    "replaceContainerIfExists": boolean, // Override container in item with this id exists. Defaults to false.
     "replaceWidthIfExists": boolean,     // Override width if item with this id exists. Defaults to false.
     "replaceHeightIfExists": boolean     // Override height if item with this id exists. Defaults to false.
 }

--- a/backend/src/api/api-routes.openapi.ts
+++ b/backend/src/api/api-routes.openapi.ts
@@ -162,8 +162,7 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
         },
         "/api/v1/board/{boardId}/item": {
             post: {
-                description:
-                    "Creates a new item on given board. If you want to add the item onto a\nspecific area/container element on the board, you can find the id of the\ncontainer by inspecting with your browser.",
+                description: "Creates a new item on given board.",
                 tags: ["Board"],
                 parameters: [
                     { name: "boardId", in: "path", required: true },
@@ -174,12 +173,15 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
                         "application/json": {
                             schema: {
                                 type: "object",
-                                required: ["type", "text", "color", "container"],
+                                required: ["x", "y", "type", "text", "color", "width", "height"],
                                 properties: {
+                                    x: { type: "number" },
+                                    y: { type: "number" },
                                     type: { type: "string", enum: ["note"] },
                                     text: { type: "string" },
                                     color: { type: "string" },
-                                    container: { type: "string" },
+                                    width: { type: "number" },
+                                    height: { type: "number" },
                                 },
                             },
                         },
@@ -202,8 +204,7 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
         },
         "/api/v1/board/{boardId}/item/{itemId}": {
             put: {
-                description:
-                    "Creates a new item on given board or updates an existing one.\nIf you want to add the item onto a specific area/container element on the board, you can\nfind the id of the container by inspecting with your browser.",
+                description: "Creates a new item on given board or updates an existing one.",
                 tags: ["Board"],
                 parameters: [
                     { name: "boardId", in: "path", required: true },
@@ -215,15 +216,21 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
                         "application/json": {
                             schema: {
                                 type: "object",
-                                required: ["type", "text", "color"],
+                                required: ["x", "y", "type", "text", "color", "width", "height"],
                                 properties: {
+                                    x: { type: "number" },
+                                    y: { type: "number" },
                                     type: { type: "string", enum: ["note"] },
                                     text: { type: "string" },
                                     color: { type: "string" },
-                                    container: { type: "string" },
+                                    width: { type: "number" },
+                                    height: { type: "number" },
+                                    replaceXIfExists: { type: "boolean" },
+                                    replaceYIfExists: { type: "boolean" },
                                     replaceTextIfExists: { type: "boolean" },
                                     replaceColorIfExists: { type: "boolean" },
-                                    replaceContainerIfExists: { type: "boolean" },
+                                    replaceWidthIfExists: { type: "boolean" },
+                                    replaceHeightIfExists: { type: "boolean" },
                                 },
                             },
                         },

--- a/backend/src/api/api-routes.openapi.ts
+++ b/backend/src/api/api-routes.openapi.ts
@@ -162,7 +162,8 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
         },
         "/api/v1/board/{boardId}/item": {
             post: {
-                description: "Creates a new item on given board.",
+                description:
+                    "Creates a new item on given board. If you want to add the item onto a\nspecific area/container element on the board, you can find the id of the\ncontainer by inspecting with your browser.",
                 tags: ["Board"],
                 parameters: [
                     { name: "boardId", in: "path", required: true },
@@ -180,6 +181,7 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
                                     type: { type: "string", enum: ["note"] },
                                     text: { type: "string" },
                                     color: { type: "string" },
+                                    container: { type: "string" },
                                     width: { type: "number" },
                                     height: { type: "number" },
                                 },
@@ -204,7 +206,8 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
         },
         "/api/v1/board/{boardId}/item/{itemId}": {
             put: {
-                description: "Creates a new item on given board or updates an existing one.",
+                description:
+                    "Creates a new item on given board or updates an existing one.\nIf you want to add the item onto a specific area/container element on the board, you can\nfind the id of the container by inspecting with your browser.",
                 tags: ["Board"],
                 parameters: [
                     { name: "boardId", in: "path", required: true },
@@ -223,12 +226,14 @@ const spec: { paths: OpenAPIV3.PathsObject } = {
                                     type: { type: "string", enum: ["note"] },
                                     text: { type: "string" },
                                     color: { type: "string" },
+                                    container: { type: "string" },
                                     width: { type: "number" },
                                     height: { type: "number" },
                                     replaceXIfExists: { type: "boolean" },
                                     replaceYIfExists: { type: "boolean" },
                                     replaceTextIfExists: { type: "boolean" },
                                     replaceColorIfExists: { type: "boolean" },
+                                    replaceContainerIfExists: { type: "boolean" },
                                     replaceWidthIfExists: { type: "boolean" },
                                     replaceHeightIfExists: { type: "boolean" },
                                 },

--- a/backend/src/api/github-webhook.ts
+++ b/backend/src/api/github-webhook.ts
@@ -54,7 +54,7 @@ export const githubWebhook = route
                     const color = isBug ? RED : YELLOW
                     if (!existingItem) {
                         console.log(`Github webhook call board ${boardId}: New item`)
-                        addItem(board, "note", linkHTML, color, "New issues")
+                        addItem(board, 5, 5, "note", linkHTML, color, 5, 5, "New issues")
                     } else {
                         console.log(`Github webhook call board ${boardId}: Item exists`)
                         const updatedItem: Note = { ...existingItem, color }

--- a/backend/src/api/github-webhook.ts
+++ b/backend/src/api/github-webhook.ts
@@ -54,7 +54,7 @@ export const githubWebhook = route
                     const color = isBug ? RED : YELLOW
                     if (!existingItem) {
                         console.log(`Github webhook call board ${boardId}: New item`)
-                        addItem(board, 5, 5, "note", linkHTML, color, 5, 5, "New issues")
+                        addItem(board, 80, 80, "note", linkHTML, color, "New issues", 5, 5)
                     } else {
                         console.log(`Github webhook call board ${boardId}: Item exists`)
                         const updatedItem: Note = { ...existingItem, color }

--- a/backend/src/api/item-create-or-update.ts
+++ b/backend/src/api/item-create-or-update.ts
@@ -5,20 +5,9 @@ import { ok } from "typera-common/response"
 import { body } from "typera-express/parser"
 import { Color, isNote, Note } from "../../../common/src/domain"
 import { ServerSideBoardState } from "../board-state"
-import {
-    addItem,
-    apiTokenHeader,
-    checkBoardAPIAccess,
-    dispatchSystemAppEvent,
-    findContainer,
-    getItemAttributesForContainer,
-    InvalidRequest,
-    route,
-} from "./utils"
+import { addItem, apiTokenHeader, checkBoardAPIAccess, dispatchSystemAppEvent, InvalidRequest, route } from "./utils"
 /**
  * Creates a new item on given board or updates an existing one.
- * If you want to add the item onto a specific area/container element on the board, you can
- * find the id of the container by inspecting with your browser.
  *
  * @tags Board
  */
@@ -29,15 +18,21 @@ export const itemCreateOrUpdate = route
         body(
             t.intersection([
                 t.type({
+                    x: t.number,
+                    y: t.number,
                     type: t.literal("note"),
                     text: NonEmptyString,
                     color: t.string,
+                    width: t.number,
+                    height: t.number,
                 }),
                 t.partial({
-                    container: t.string,
+                    replaceXIfExists: t.boolean,
+                    replaceYIfExists: t.boolean,
                     replaceTextIfExists: t.boolean,
                     replaceColorIfExists: t.boolean,
-                    replaceContainerIfExists: t.boolean,
+                    replaceWidthIfExists: t.boolean,
+                    replaceHeightIfExists: t.boolean,
                 }),
             ]),
         ),
@@ -46,31 +41,43 @@ export const itemCreateOrUpdate = route
         checkBoardAPIAccess(request, async (board) => {
             const { itemId } = request.routeParams
             let {
+                x,
+                y,
                 type,
                 text,
                 color,
-                container,
+                width,
+                height,
+                replaceXIfExists,
+                replaceYIfExists,
                 replaceTextIfExists,
                 replaceColorIfExists,
-                replaceContainerIfExists = true,
+                replaceWidthIfExists,
+                replaceHeightIfExists,
             } = request.body
             console.log(`PUT item for board ${board.board.id} item ${itemId}: ${JSON.stringify(request.req.body)}`)
             const existingItem = board.board.items[itemId]
             if (existingItem) {
                 updateItem(
                     board,
+                    x,
+                    y,
                     type,
                     text,
                     color,
-                    container,
+                    width,
+                    height,
                     itemId,
+                    replaceXIfExists,
+                    replaceYIfExists,
                     replaceTextIfExists,
                     replaceColorIfExists,
-                    replaceContainerIfExists,
+                    replaceWidthIfExists,
+                    replaceHeightIfExists,
                 )
             } else {
                 console.log(`Adding new item`)
-                addItem(board, type, text, color, container, itemId)
+                addItem(board, x, y, type, text, color, width, height, itemId)
             }
             return ok({ ok: true })
         }),
@@ -78,31 +85,34 @@ export const itemCreateOrUpdate = route
 
 function updateItem(
     board: ServerSideBoardState,
+    x: number,
+    y: number,
     type: "note",
     text: string,
     color: Color,
-    container: string | undefined,
+    width: number,
+    height: number,
     itemId: string,
+    replaceXIfExists: boolean | undefined,
+    replaceYIfExists: boolean | undefined,
     replaceTextIfExists: boolean | undefined,
     replaceColorIfExists: boolean | undefined,
-    replaceContainerIfExists: boolean | undefined,
+    replaceWidthIfExists: boolean | undefined,
+    replaceHeightIfExists: boolean | undefined,
 ) {
     const existingItem = board.board.items[itemId]
     if (!isNote(existingItem)) {
         throw new InvalidRequest("Unexpected item type")
     }
-    const containerItem = findContainer(container, board.board)
-    const currentContainer = findContainer(existingItem.containerId, board.board)
-    const containerAttrs =
-        replaceContainerIfExists && containerItem !== currentContainer
-            ? getItemAttributesForContainer(container, board.board)
-            : {}
 
     let updatedItem: Note = {
         ...existingItem,
-        ...containerAttrs,
+        x: replaceXIfExists !== false ? x : existingItem.x,
+        y: replaceYIfExists !== false ? y : existingItem.y,
         text: replaceTextIfExists !== false ? text : existingItem.text,
         color: replaceColorIfExists !== false ? color || existingItem.color : existingItem.color,
+        width: replaceWidthIfExists !== false ? width : existingItem.width,
+        height: replaceHeightIfExists !== false ? height : existingItem.height,
     }
     if (!_.isEqual(updatedItem, existingItem)) {
         console.log(`Updating existing item`)

--- a/backend/src/api/item-create.ts
+++ b/backend/src/api/item-create.ts
@@ -4,9 +4,7 @@ import { body } from "typera-express/parser"
 import { addItem, apiTokenHeader, checkBoardAPIAccess, route } from "./utils"
 
 /**
- * Creates a new item on given board. If you want to add the item onto a
- * specific area/container element on the board, you can find the id of the
- * container by inspecting with your browser.
+ * Creates a new item on given board.
  *
  * @tags Board
  */
@@ -14,13 +12,23 @@ export const itemCreate = route
     .post("/api/v1/board/:boardId/item")
     .use(
         apiTokenHeader,
-        body(t.type({ type: t.literal("note"), text: t.string, color: t.string, container: t.string })),
+        body(
+            t.type({
+                x: t.number,
+                y: t.number,
+                type: t.literal("note"),
+                text: t.string,
+                color: t.string,
+                width: t.number,
+                height: t.number,
+            }),
+        ),
     )
     .handler((request) =>
         checkBoardAPIAccess(request, async (board) => {
-            const { type, text, color, container } = request.body
+            const { x, y, type, text, color, width, height } = request.body
             console.log(`POST item for board ${board.board.id}: ${JSON.stringify(request.req.body)}`)
-            const item = addItem(board, type, text, color, container)
+            const item = addItem(board, x, y, type, text, color, width, height)
             return ok(item)
         }),
     )

--- a/backend/src/api/item-create.ts
+++ b/backend/src/api/item-create.ts
@@ -4,7 +4,9 @@ import { body } from "typera-express/parser"
 import { addItem, apiTokenHeader, checkBoardAPIAccess, route } from "./utils"
 
 /**
- * Creates a new item on given board.
+ * Creates a new item on given board. If you want to add the item onto a
+ * specific area/container element on the board, you can find the id of the
+ * container by inspecting with your browser.
  *
  * @tags Board
  */
@@ -13,22 +15,27 @@ export const itemCreate = route
     .use(
         apiTokenHeader,
         body(
-            t.type({
-                x: t.number,
-                y: t.number,
-                type: t.literal("note"),
-                text: t.string,
-                color: t.string,
-                width: t.number,
-                height: t.number,
-            }),
+            t.intersection([
+                t.type({
+                    x: t.number,
+                    y: t.number,
+                    type: t.literal("note"),
+                    text: t.string,
+                    color: t.string,
+                    width: t.number,
+                    height: t.number,
+                }),
+                t.partial({
+                    container: t.string,
+                }),
+            ]),
         ),
     )
     .handler((request) =>
         checkBoardAPIAccess(request, async (board) => {
-            const { x, y, type, text, color, width, height } = request.body
+            const { x, y, type, text, color, container, width, height } = request.body
             console.log(`POST item for board ${board.board.id}: ${JSON.stringify(request.req.body)}`)
-            const item = addItem(board, x, y, type, text, color, width, height)
+            const item = addItem(board, x, y, type, text, color, container, width, height)
             return ok(item)
         }),
     )

--- a/backend/src/api/utils.ts
+++ b/backend/src/api/utils.ts
@@ -52,6 +52,35 @@ export async function checkBoardAPIAccess<T>(
     }
 }
 
+export function findContainer(container: string | undefined, board: Board): Container | null {
+    if (container !== undefined) {
+        if (typeof container !== "string") {
+            throw new InvalidRequest("Expecting container to be undefined, or an id or name of an Container item")
+        }
+        const containerItem = Object.values(board.items).find(
+            (i) => i.type === "container" && (i.text.toLowerCase() === container.toLowerCase() || i.id === container),
+        )
+        if (!containerItem) {
+            throw new InvalidRequest(`Container "${container}" not found by id or name`)
+        }
+        return containerItem as Container
+    } else {
+        return null
+    }
+}
+
+export function getItemAttributesForContainer(container: string | undefined, board: Board) {
+    const containerItem = findContainer(container, board)
+    if (containerItem) {
+        return {
+            containerId: containerItem.id,
+            x: containerItem.x + 2,
+            y: containerItem.y + 2,
+        }
+    }
+    return {}
+}
+
 export function dispatchSystemAppEvent(board: ServerSideBoardState, appEvent: PersistableBoardItemEvent) {
     const user: EventUserInfo = { userType: "system", nickname: "Github webhook" }
     let historyEntry: BoardHistoryEntry = { ...appEvent, user, timestamp: newISOTimeStamp() }
@@ -69,6 +98,7 @@ export function addItem(
     type: "note",
     text: string,
     color: Color,
+    container: string | undefined,
     width: number,
     height: number,
     itemId?: string,
@@ -76,7 +106,10 @@ export function addItem(
     if (type !== "note") throw new InvalidRequest("Expecting type: note")
     if (typeof text !== "string" || text.length === 0) throw new InvalidRequest("Expecting non zero-length text")
 
-    const item: Note = { ...newNote(text, color || DEFAULT_NOTE_COLOR, x, y, width, height) }
+    let itemAttributes: object = getItemAttributesForContainer(container, board.board)
+    if (itemId) itemAttributes = { ...itemAttributes, id: itemId }
+
+    const item: Note = { ...newNote(text, color || DEFAULT_NOTE_COLOR, x, y, width, height), ...itemAttributes }
     const appEvent: AppEvent = { action: "item.add", boardId: board.board.id, items: [item], connections: [] }
     dispatchSystemAppEvent(board, appEvent)
     return item

--- a/common/src/domain.ts
+++ b/common/src/domain.ts
@@ -404,8 +404,9 @@ export function newNote(
     height: number = 5,
     shape: NoteShape = "square",
     z: number = 0,
+    fontSize: number = 1,
 ): Note {
-    return { id: uuid.v4(), type: "note", text, color, x, y, width, height, z, shape, locked: false }
+    return { id: uuid.v4(), type: "note", text, color, x, y, width, height, z, shape, locked: false, fontSize }
 }
 
 export function newSimilarNote(note: Note) {

--- a/playwright/src/pages/BoardApi.ts
+++ b/playwright/src/pages/BoardApi.ts
@@ -38,10 +38,13 @@ export function BoardApi(page: Page) {
             return await test.step("Add item " + text, async () => {
                 const response = await page.request.post(`/api/v1/board/${boardId}/item`, {
                     data: {
+                        x: 0,
+                        y: 15,
                         type: "note",
                         text,
-                        container: "API notes",
                         color: "#000000",
+                        width: 10,
+                        height: 5,
                     },
                     headers: {
                         API_TOKEN: accessToken,

--- a/playwright/src/pages/BoardApi.ts
+++ b/playwright/src/pages/BoardApi.ts
@@ -38,12 +38,13 @@ export function BoardApi(page: Page) {
             return await test.step("Add item " + text, async () => {
                 const response = await page.request.post(`/api/v1/board/${boardId}/item`, {
                     data: {
-                        x: 0,
-                        y: 15,
+                        x: 10,
+                        y: 40,
                         type: "note",
                         text,
+                        container: "API notes",
                         color: "#000000",
-                        width: 10,
+                        width: 5,
                         height: 5,
                     },
                     headers: {

--- a/playwright/src/tests/api.spec.ts
+++ b/playwright/src/tests/api.spec.ts
@@ -32,9 +32,13 @@ test.describe("API endpoints", () => {
 
         await test.step("Update item", async () => {
             await Api.updateItem(accessToken, id, item.id, {
+                x: 163,
+                y: 460,
                 type: "note",
                 text: "Updated item",
                 color: "#000000",
+                width: 5,
+                height: 5,
             })
             await expect(board.getNote("Updated item")).toBeVisible()
         })
@@ -42,10 +46,14 @@ test.describe("API endpoints", () => {
         await test.step("Change item container", async () => {
             await board.assertItemPosition(board.getNote("Updated item"), 163, 460)
             await Api.updateItem(accessToken, id, item.id, {
+                x: 613,
+                y: 460,
                 type: "note",
                 text: "Updated item",
                 color: "#000000",
                 container: "More API notes",
+                width: 5,
+                height: 5,
             })
             await sleep(1000)
             await board.assertItemPosition(board.getNote("Updated item"), 613, 460)


### PR DESCRIPTION
Existing: Notes are created and updated with container parameter

New Updates: Now we can create and update notes without passing container parameter and with passing container parameter

Reg:testing with playwright, I have been developing in codespace, so could not able to run few tests , but 90% of test is successful with playwright.
I have tested all possible scenario's using postman and it works good.
