### PR TITLE
Make a few tests more stable

### DIFF
--- a/playwright/src/pages/BoardPage.ts
+++ b/playwright/src/pages/BoardPage.ts
@@ -158,7 +158,9 @@ export function BoardPage(page: Page, browser: Browser) {
         async createNoteWithText(x: number, y: number, text: string) {
             return await test.step("Create note " + text, async () => {
                 await createNew(this.newNoteOnPalette, x, y)
-                await page.keyboard.type(`${text}`)
+                const elt = page.locator(".note.selected .editable")
+                await expect(elt).toBeVisible()
+                await elt.fill(text)
                 await page.keyboard.press("Escape")
                 await expect(this.getNote(text)).toBeVisible()
                 const result = this.getNote(text)
@@ -188,7 +190,7 @@ export function BoardPage(page: Page, browser: Browser) {
             return await test.step("Create area " + text, async () => {
                 await createNew(this.newContainerOnPalette, x, y)
                 await this.getArea("Unnamed area").locator(".text").dblclick()
-                await page.keyboard.type(`${text}`)
+                await page.locator("*:focus").fill(text)
                 await expect(this.getArea(text)).toBeVisible()
                 const result = this.getArea(text)
                 await expect(result).toHaveText(text)

--- a/playwright/src/tests/api.spec.ts
+++ b/playwright/src/tests/api.spec.ts
@@ -87,19 +87,21 @@ test.describe("API endpoints", () => {
         })
 
         await test.step("Get board state", async () => {
-            const content = await Api.getBoard(accessToken, id)
-            expect(content).toEqual({
-                board: {
-                    id,
-                    name: "Updated board name",
-                    width: 800,
-                    height: 600,
-                    serial: expect.anything(),
-                    connections: [],
-                    items: expect.anything(),
-                },
-            })
+            expect
+                .poll(async () => await Api.getBoard(accessToken, id))
+                .toEqual({
+                    board: {
+                        id,
+                        name: "Updated board name",
+                        width: 800,
+                        height: 600,
+                        serial: expect.anything(),
+                        connections: [],
+                        items: expect.anything(),
+                    },
+                })
 
+            const content = await Api.getBoard(accessToken, id)
             expect(Object.values(content.board.items)).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
@@ -115,18 +117,19 @@ test.describe("API endpoints", () => {
         })
 
         await test.step("Get board state hierarchy", async () => {
-            const content = await Api.getBoardHierarchy(accessToken, id)
-            expect(content).toEqual({
-                board: {
-                    id,
-                    name: "Updated board name",
-                    width: 800,
-                    height: 600,
-                    serial: expect.anything(),
-                    connections: [],
-                    items: expect.anything(),
-                },
-            })
+            expect
+                .poll(async () => await Api.getBoardHierarchy(accessToken, id))
+                .toEqual({
+                    board: {
+                        id,
+                        name: "Updated board name",
+                        width: 800,
+                        height: 600,
+                        serial: expect.anything(),
+                        connections: [],
+                        items: expect.anything(),
+                    },
+                })
         })
 
         await test.step("Get board history", async () => {


### PR DESCRIPTION
I was seeing occasional failures especially on firefox, and these changes seem to improve the stability for me.

Use `locator.fill` instead of `keyboard.type` (as recommended in [Playwright documentation](https://playwright.dev/docs/api/class-keyboard#keyboard-type)).

Use `expect.poll` on some API calls where the update doesn't appear to be instant.
